### PR TITLE
Unite MotionImitator and ToggleImitator

### DIFF
--- a/backboard-example/src/main/java/com/tumblr/backboard/example/AppearFragment.java
+++ b/backboard-example/src/main/java/com/tumblr/backboard/example/AppearFragment.java
@@ -9,6 +9,7 @@ import com.facebook.rebound.Spring;
 import com.facebook.rebound.SpringSystem;
 import com.tumblr.backboard.Actor;
 import com.tumblr.backboard.MotionProperty;
+import com.tumblr.backboard.imitator.EventImitator;
 import com.tumblr.backboard.imitator.MotionImitator;
 import com.tumblr.backboard.performer.Performer;
 
@@ -57,12 +58,15 @@ public class AppearFragment extends Fragment {
 					actors[i].setTouchEnabled(false);
 
 					for (Actor.Motion motion : actors[i].getMotions()) {
-						for (MotionImitator imitator : motion.getImitators()) {
-							if (imitator.getProperty() == MotionProperty.Y) {
-								// TODO: disable the y-motion because it is about to be animated.
-								// imitator.getSpring().deregister();
-							} else {
-								imitator.release(null);
+						for (EventImitator imitator : motion.getImitators()) {
+							if (imitator instanceof MotionImitator) {
+								final MotionImitator motionImitator = (MotionImitator) imitator;
+								if (motionImitator.getProperty() == MotionProperty.Y) {
+									// TODO: disable the y-motion because it is about to be animated
+									// imitator.getSpring().deregister();
+								} else {
+									imitator.release(null);
+								}
 							}
 						}
 					}
@@ -121,14 +125,17 @@ public class AppearFragment extends Fragment {
 						actors[i].setTouchEnabled(true);
 
 						for (Actor.Motion motion : actors[i].getMotions()) {
-							for (MotionImitator imitator : motion.getImitators()) {
-								imitator.getSpring().setCurrentValue(0);
+							for (EventImitator imitator : motion.getImitators()) {
+								if (imitator instanceof MotionImitator) {
+									final MotionImitator motionImitator = (MotionImitator) imitator;
+									imitator.getSpring().setCurrentValue(0);
 
-								// TODO: re-enable the y motion.
-//								if (imitator.getProperty() == MotionProperty.Y &&
-//										!imitator.getSpring().isRegistered()) {
-//									imitator.getSpring().register();
-//								}
+									// TODO: re-enable the y motion.
+//									if (imitator.getProperty() == MotionProperty.Y &&
+//											!imitator.getSpring().isRegistered()) {
+//										imitator.getSpring().register();
+//									}
+								}
 							}
 						}
 

--- a/backboard-example/src/main/java/com/tumblr/backboard/example/BackboardActivity.java
+++ b/backboard-example/src/main/java/com/tumblr/backboard/example/BackboardActivity.java
@@ -107,6 +107,13 @@ public class BackboardActivity extends Activity {
 					.commit();
 			setTitle(R.string.action_constrained);
 			return true;
+
+		case R.id.action_press:
+			getFragmentManager().beginTransaction()
+					.replace(R.id.container, new PressFragment())
+					.commit();
+			setTitle(R.string.action_press);
+			return true;
 		}
 
 		return super.onOptionsItemSelected(item);

--- a/backboard-example/src/main/java/com/tumblr/backboard/example/FlowerFragment.java
+++ b/backboard-example/src/main/java/com/tumblr/backboard/example/FlowerFragment.java
@@ -9,6 +9,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.RelativeLayout;
+
 import com.facebook.rebound.Spring;
 import com.facebook.rebound.SpringSystem;
 import com.tumblr.backboard.Actor;
@@ -159,15 +160,7 @@ public class FlowerFragment extends Fragment {
 		new Actor.Builder(SpringSystem.create(), mCircle)
 				.addMotion(new SnapImitator(MotionProperty.X), View.TRANSLATION_X)
 				.addMotion(new SnapImitator(MotionProperty.Y), View.TRANSLATION_Y)
-				.onTouchListener(new View.OnTouchListener() {
-					@Override
-					public boolean onTouch(View v, MotionEvent event) {
-						// bloom!
-						imitator.imitate(v, event);
-
-						return true;
-					}
-				})
+				.onTouchListener(imitator)
 				.build();
 
 		return mRootView;

--- a/backboard-example/src/main/java/com/tumblr/backboard/example/FlowerFragment.java
+++ b/backboard-example/src/main/java/com/tumblr/backboard/example/FlowerFragment.java
@@ -163,7 +163,7 @@ public class FlowerFragment extends Fragment {
 					@Override
 					public boolean onTouch(View v, MotionEvent event) {
 						// bloom!
-						imitator.imitate(event);
+						imitator.imitate(v, event);
 
 						return true;
 					}

--- a/backboard-example/src/main/java/com/tumblr/backboard/example/PressFragment.java
+++ b/backboard-example/src/main/java/com/tumblr/backboard/example/PressFragment.java
@@ -1,0 +1,36 @@
+package com.tumblr.backboard.example;
+
+import android.app.Fragment;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.facebook.rebound.SpringListener;
+import com.facebook.rebound.SpringSystem;
+import com.tumblr.backboard.Actor;
+import com.tumblr.backboard.imitator.ToggleImitator;
+import com.tumblr.backboard.performer.MapPerformer;
+import com.tumblr.backboard.performer.Performer;
+
+/**
+ * Demonstrates a view that shrinks when touched and bounces back when released.
+ * <p/>
+ * Created by ericleong on 11/28/15.
+ */
+public class PressFragment extends Fragment {
+
+	@Override
+	public View onCreateView(LayoutInflater inflater, ViewGroup container,
+	                         Bundle savedInstanceState) {
+
+		final View rootView = inflater.inflate(R.layout.fragment_press, container, false);
+
+		new Actor.Builder(SpringSystem.create(), rootView.findViewById(R.id.circle))
+				.addMotion(new ToggleImitator(null, 1.0, 0.5),
+						new Performer(View.SCALE_X), new Performer(View.SCALE_Y))
+				.build();
+
+		return rootView;
+	}
+}

--- a/backboard-example/src/main/java/com/tumblr/backboard/example/PressFragment.java
+++ b/backboard-example/src/main/java/com/tumblr/backboard/example/PressFragment.java
@@ -6,12 +6,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.facebook.rebound.SpringListener;
 import com.facebook.rebound.SpringSystem;
 import com.tumblr.backboard.Actor;
 import com.tumblr.backboard.imitator.ToggleImitator;
-import com.tumblr.backboard.performer.MapPerformer;
-import com.tumblr.backboard.performer.Performer;
 
 /**
  * Demonstrates a view that shrinks when touched and bounces back when released.
@@ -27,8 +24,7 @@ public class PressFragment extends Fragment {
 		final View rootView = inflater.inflate(R.layout.fragment_press, container, false);
 
 		new Actor.Builder(SpringSystem.create(), rootView.findViewById(R.id.circle))
-				.addMotion(new ToggleImitator(null, 1.0, 0.5),
-						new Performer(View.SCALE_X), new Performer(View.SCALE_Y))
+				.addMotion(new ToggleImitator(null, 1.0, 0.5), View.SCALE_X, View.SCALE_Y)
 				.build();
 
 		return rootView;

--- a/backboard-example/src/main/res/layout/fragment_press.xml
+++ b/backboard-example/src/main/res/layout/fragment_press.xml
@@ -1,0 +1,14 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:gravity="center"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+	<View
+		android:id="@+id/circle"
+		android:background="@drawable/circle_green"
+		android:layout_gravity="center"
+		android:layout_width="200dp"
+		android:layout_height="200dp" />
+
+</LinearLayout>

--- a/backboard-example/src/main/res/menu/backboard.xml
+++ b/backboard-example/src/main/res/menu/backboard.xml
@@ -51,4 +51,9 @@
 		android:title="@string/action_constrained"
 		android:orderInCategory="100"
 		android:showAsAction="never" />
+
+	<item android:id="@+id/action_press"
+		android:title="@string/action_press"
+		android:orderInCategory="100"
+		android:showAsAction="never" />
 </menu>

--- a/backboard-example/src/main/res/values/strings.xml
+++ b/backboard-example/src/main/res/values/strings.xml
@@ -12,5 +12,6 @@
     <string name="action_follow">Follow</string>
     <string name="action_zoom">Zoom</string>
     <string name="action_constrained">Constrain</string>
+    <string name="action_press">Press</string>
 
 </resources>

--- a/backboard/src/main/java/com/tumblr/backboard/Actor.java
+++ b/backboard/src/main/java/com/tumblr/backboard/Actor.java
@@ -9,6 +9,7 @@ import android.view.ViewConfiguration;
 import com.facebook.rebound.Spring;
 import com.facebook.rebound.SpringListener;
 import com.facebook.rebound.SpringSystem;
+import com.tumblr.backboard.imitator.EventImitator;
 import com.tumblr.backboard.imitator.Imitator;
 import com.tumblr.backboard.imitator.MotionImitator;
 import com.tumblr.backboard.performer.Performer;
@@ -40,18 +41,26 @@ public final class Actor {
 		@NonNull
 		private final Spring spring;
 		@NonNull
-		private final MotionImitator[] imitators;
+		private final EventImitator[] imitators;
 		@NonNull
 		private final Performer[] performers;
 		@Nullable
 		private final SpringListener[] springListeners;
 
-		private Motion(@NonNull Spring spring, @NonNull MotionImitator imitator, @NonNull Performer[] performers,
+		private Motion(@NonNull Spring spring, @NonNull EventImitator imitator, @NonNull Performer[] performers,
 		               @Nullable SpringListener[] springListeners) {
-			this(spring, new MotionImitator[] { imitator }, performers, springListeners);
+			this(spring, new EventImitator[] { imitator }, performers, springListeners);
 		}
 
-		private Motion(@NonNull Spring spring, @NonNull MotionImitator[] imitators, @NonNull Performer[] performers,
+		private Motion(@NonNull Spring spring, @NonNull Performer[] performers,
+		               @Nullable SpringListener[] springListeners) {
+			this.imitators = new MotionImitator[0];
+			this.performers = performers;
+			this.spring = spring;
+			this.springListeners = springListeners;
+		}
+
+		private Motion(@NonNull Spring spring, @NonNull EventImitator[] imitators, @NonNull Performer[] performers,
 		               @Nullable SpringListener[] springListeners) {
 			this.imitators = imitators;
 			this.performers = performers;
@@ -65,7 +74,7 @@ public final class Actor {
 		}
 
 		@NonNull
-		public MotionImitator[] getImitators() {
+		public EventImitator[] getImitators() {
 			return imitators;
 		}
 	}
@@ -405,7 +414,7 @@ public final class Actor {
 		/**
 		 * Uses a default {@link com.facebook.rebound.SpringConfig}.
 		 *
-		 * @param motionImitator
+		 * @param eventImitator
 		 * 		maps an event to a {@link com.facebook.rebound.Spring}
 		 * @param performers
 		 * 		map the {@link com.facebook.rebound.Spring} to a
@@ -413,14 +422,14 @@ public final class Actor {
 		 * @return the builder for chaining
 		 */
 		@NonNull
-		public Builder addMotion(@NonNull MotionImitator motionImitator, Performer... performers) {
-			return addMotion(mSpringSystem.createSpring(), motionImitator, performers);
+		public Builder addMotion(@NonNull EventImitator eventImitator, Performer... performers) {
+			return addMotion(mSpringSystem.createSpring(), eventImitator, performers);
 		}
 
 		/**
 		 * @param spring
 		 * 		the underlying {@link com.facebook.rebound.Spring}.
-		 * @param motionImitator
+		 * @param eventImitator
 		 * 		maps an event to a {@link com.facebook.rebound.Spring}
 		 * @param performers
 		 * 		map the {@link com.facebook.rebound.Spring} to a
@@ -428,10 +437,10 @@ public final class Actor {
 		 * @return the builder for chaining
 		 */
 		@NonNull
-		public Builder addMotion(@NonNull Spring spring, @NonNull MotionImitator motionImitator,
+		public Builder addMotion(@NonNull Spring spring, @NonNull EventImitator eventImitator,
 		                         @NonNull Performer... performers) {
 
-			Motion motion = new Motion(spring, motionImitator, performers, null);
+			Motion motion = new Motion(spring, eventImitator, performers, null);
 
 			// connect actors
 			motion.imitators[0].setSpring(motion.spring);
@@ -448,7 +457,7 @@ public final class Actor {
 		/**
 		 * @param spring
 		 * 		the underlying {@link com.facebook.rebound.Spring}.
-		 * @param motionImitator
+		 * @param eventImitator
 		 * 		maps an event to a {@link com.facebook.rebound.Spring}
 		 * @param performers
 		 * 		map the {@link com.facebook.rebound.Spring} to a
@@ -458,11 +467,11 @@ public final class Actor {
 		 * @return the builder for chaining
 		 */
 		@NonNull
-		public Builder addMotion(@NonNull Spring spring, @NonNull MotionImitator motionImitator,
+		public Builder addMotion(@NonNull Spring spring, @NonNull EventImitator eventImitator,
 		                         @NonNull Performer[] performers, SpringListener[] springListeners) {
 
 			// create struct
-			Motion motion = new Motion(spring, motionImitator, performers, springListeners);
+			final Motion motion = new Motion(spring, eventImitator, performers, springListeners);
 
 			// connect actors
 			motion.imitators[0].setSpring(motion.spring);
@@ -599,7 +608,7 @@ public final class Actor {
 			}
 
 			for (Motion motion : mMotions) {
-				for (MotionImitator imitator : motion.imitators) {
+				for (EventImitator imitator : motion.imitators) {
 					imitator.imitate(v, event);
 				}
 			}

--- a/backboard/src/main/java/com/tumblr/backboard/Actor.java
+++ b/backboard/src/main/java/com/tumblr/backboard/Actor.java
@@ -393,14 +393,14 @@ public final class Actor {
 		/**
 		 * Uses a default {@link com.facebook.rebound.SpringConfig}.
 		 *
-		 * @param motionImitator
+		 * @param eventImitator
 		 * 		maps an event to a {@link com.facebook.rebound.Spring}
 		 * @param viewProperties
 		 * 		the {@link android.view.View} property to animate
 		 * @return the builder for chaining
 		 */
 		@NonNull
-		public Builder addMotion(@NonNull MotionImitator motionImitator,
+		public Builder addMotion(@NonNull EventImitator eventImitator,
 		                         @NonNull Property<View, Float>... viewProperties) {
 			Performer[] performers = new Performer[viewProperties.length];
 
@@ -408,7 +408,7 @@ public final class Actor {
 				performers[i] = new Performer(viewProperties[i]);
 			}
 
-			return addMotion(mSpringSystem.createSpring(), motionImitator, performers);
+			return addMotion(mSpringSystem.createSpring(), eventImitator, performers);
 		}
 
 		/**

--- a/backboard/src/main/java/com/tumblr/backboard/imitator/EventImitator.java
+++ b/backboard/src/main/java/com/tumblr/backboard/imitator/EventImitator.java
@@ -3,6 +3,8 @@ package com.tumblr.backboard.imitator;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.MotionEvent;
+import android.view.View;
+
 import com.facebook.rebound.Spring;
 
 /**
@@ -108,7 +110,7 @@ public abstract class EventImitator extends Imitator {
 	 * @param event
 	 * 		the motion event
 	 */
-	public void imitate(float offset, float value, float delta, @Nullable MotionEvent event) {
+	protected void imitate(float offset, float value, float delta, @Nullable MotionEvent event) {
 		if (event != null) {
 			switch (event.getAction()) {
 			case MotionEvent.ACTION_DOWN:
@@ -131,4 +133,14 @@ public abstract class EventImitator extends Imitator {
 			}
 		}
 	}
+
+	/**
+	 * Maps a user's motion to {@link android.view.View} via a {@link com.facebook.rebound.Spring}.
+	 *
+	 * @param view
+	 * 		the view to perturb.
+	 * @param event
+	 * 		the motion to imitate.
+	 */
+	public abstract void imitate(final View view, @NonNull MotionEvent event);
 }

--- a/backboard/src/main/java/com/tumblr/backboard/imitator/Imitator.java
+++ b/backboard/src/main/java/com/tumblr/backboard/imitator/Imitator.java
@@ -149,5 +149,10 @@ public abstract class Imitator {
 
 	public void setSpring(@NonNull Spring spring) {
 		mSpring = spring;
+
+		if (mSpring != null) {
+			// Start spring at rest.
+			mSpring.setCurrentValue(mRestValue, true);
+		}
 	}
 }

--- a/backboard/src/main/java/com/tumblr/backboard/imitator/MotionImitator.java
+++ b/backboard/src/main/java/com/tumblr/backboard/imitator/MotionImitator.java
@@ -144,14 +144,7 @@ public class MotionImitator extends EventImitator {
 		mDownPosition = mProperty.getValue(event) + mOffset;
 	}
 
-	/**
-	 * Maps a user's motion to {@link android.view.View} via a {@link com.facebook.rebound.Spring}.
-	 *
-	 * @param view
-	 * 		the view to perturb.
-	 * @param event
-	 * 		the motion to imitate.
-	 */
+	@Override
 	public void imitate(final View view, @NonNull MotionEvent event) {
 
 		final float viewValue = mProperty.getValue(view);

--- a/backboard/src/main/java/com/tumblr/backboard/imitator/ToggleImitator.java
+++ b/backboard/src/main/java/com/tumblr/backboard/imitator/ToggleImitator.java
@@ -42,28 +42,25 @@ public class ToggleImitator extends EventImitator implements View.OnTouchListene
 		return mActiveValue;
 	}
 
-	/**
-	 * @param event
-	 * 		the event to imitate.
-	 */
-	public void imitate(@NonNull MotionEvent event) {
-		switch (event.getAction()) {
-		case MotionEvent.ACTION_DOWN:
-			constrain(event);
-			break;
+	@Override
+	public boolean onTouch(View v, @NonNull MotionEvent event) {
+		imitate(v, event);
 
-		case MotionEvent.ACTION_UP:
-			release(event);
-			break;
-
-		default:
-		}
+		return true;
 	}
 
 	@Override
-	public boolean onTouch(View v, @NonNull MotionEvent event) {
-		imitate(event);
+	public void imitate(View view, @NonNull MotionEvent event) {
+		switch (event.getAction()) {
+			case MotionEvent.ACTION_DOWN:
+				constrain(event);
+				break;
 
-		return true;
+			case MotionEvent.ACTION_UP:
+				release(event);
+				break;
+
+			default:
+		}
 	}
 }

--- a/backboard/src/main/java/com/tumblr/backboard/imitator/ToggleImitator.java
+++ b/backboard/src/main/java/com/tumblr/backboard/imitator/ToggleImitator.java
@@ -56,7 +56,6 @@ public class ToggleImitator extends EventImitator implements View.OnTouchListene
 				constrain(event);
 				break;
 
-			case MotionEvent.ACTION_CANCEL:
 			case MotionEvent.ACTION_UP:
 				release(event);
 				break;

--- a/backboard/src/main/java/com/tumblr/backboard/imitator/ToggleImitator.java
+++ b/backboard/src/main/java/com/tumblr/backboard/imitator/ToggleImitator.java
@@ -56,6 +56,7 @@ public class ToggleImitator extends EventImitator implements View.OnTouchListene
 				constrain(event);
 				break;
 
+			case MotionEvent.ACTION_CANCEL:
 			case MotionEvent.ACTION_UP:
 				release(event);
 				break;


### PR DESCRIPTION
`EventImitator` is a bit of a strange class. It provides an `imitate()` method, but it's never called directly, since `Actor` uses `MotionImitator` directly. That leaves `ToggleImitator` in a weird spot because `Actor` is no longer able to use it. This pull request seeks to bring `ToggleImitator` back into the fold by:
- Adding an abstract method, `imitate(View, MotionEvent)`. This matches `View.OnClickListener`.
- Refactoring `Actor` to use `EventImitator` instead of `MotionEvent` in arguments, so that any subclass may be passed in.

This pull request was inspired by the [Rebound demo](http://facebook.github.io/rebound/). It can now be implemented with:

``` java
new Actor.Builder(SpringSystem.create(), view)
                .addMotion(new ToggleImitator(null, 1.0, 0.5), View.SCALE_X, View.SCALE_Y)
                .build();
```

A new demo can be found in `PressFragment`.

One bug was discovered and fixed in this pull request: `Imitator.setSpring()` does not set the rest value or current value of the new spring. fed6a2e sets the current value of the spring to the rest value of the `Imitator`.

A small optimization was made by passing the `ToggleImitator` as the `View.OnTouchListener` of the `Actor` in `FlowerFragment`.
### testing

Open each of the demos and ensure that they act as expected.
