### PR TITLE
Fix release() call at wrong time.

### DIFF
--- a/backboard/src/main/java/com/tumblr/backboard/imitator/EventImitator.java
+++ b/backboard/src/main/java/com/tumblr/backboard/imitator/EventImitator.java
@@ -125,7 +125,6 @@ public abstract class EventImitator extends Imitator {
 				}
 
 				break;
-			default:
 			case MotionEvent.ACTION_UP:
 				release(event);
 


### PR DESCRIPTION
Other MotionEvent for example:ACTION_POINTER_DOWN... will cause release call at wrong time
if MotionEvent switch default is MotionEvent.ACTION_UP.

for example:

I have a view which can drop with finger.

If user drop on the way and other finger touch screen, it will cause view jump random.
