### PR TITLE
Add Javadoc Task to Gradle

### DIFF
--- a/backboard/build.gradle
+++ b/backboard/build.gradle
@@ -70,5 +70,17 @@ task checkstyle(type: Checkstyle) {
     classpath = files()
 }
 
+android.libraryVariants.all { variant ->
+    task("javadoc${variant.name}", type: Javadoc) {
+        source = variant.javaCompile.source
+        ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
+        classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
+        options.links("http://docs.oracle.com/javase/7/docs/api/")
+        options.links("http://developer.android.com/reference/reference/")
+        exclude '**/BuildConfig.java'
+        exclude '**/R.java'
+    }
+}
+
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'

--- a/backboard/build.gradle
+++ b/backboard/build.gradle
@@ -76,7 +76,8 @@ android.libraryVariants.all { variant ->
         ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
         classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
         options.links("http://docs.oracle.com/javase/7/docs/api/")
-        options.links("http://developer.android.com/reference/reference/")
+        options.linksOffline("http://developer.android.com/reference/", "${android.sdkDirectory}/docs/reference/")
+        options.links("http://facebook.github.io/rebound/javadocs/")
         exclude '**/BuildConfig.java'
         exclude '**/R.java'
     }


### PR DESCRIPTION
### running

Generate Javadoc with:

``` bash
$ ./gradlew javadocRelease
```

Instead of `Release`, any build variant could be substituted (like `Debug`).

The generated Javadoc is in

```
/backboard/build/docs/javadoc
```
### publishing

To publish the Javadoc, move the above directory to `/javadoc` in the `gh-pages` branch. This appears to the public as 

http://tumblr.github.io/Backboard/javadoc/
#### redirect

To redirect from the root directory, http://tumblr.github.io/Backboard, to the Javadoc, [`jekyll-redirect-from`](https://help.github.com/articles/redirects-on-github-pages/) is used.

In the root directory, an `index.html` file was created with these contents:

``` yaml

---
redirect_to: "./javadoc"

---
```
