### PR TITLE
Plugin DSL and javadoc improvements

### DIFF
--- a/backboard-example/build.gradle
+++ b/backboard-example/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'com.android.application'
+plugins {
+    id "com.android.application"
+    id "checkstyle"
+}
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/backboard-example/build.gradle
+++ b/backboard-example/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "checkstyle"
 }
 
 android {

--- a/backboard-example/src/main/AndroidManifest.xml
+++ b/backboard-example/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name=".BackboardActivity"
+            android:exported="true"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/backboard/build.gradle
+++ b/backboard/build.gradle
@@ -21,12 +21,9 @@ android {
 
     libraryVariants.all { variant ->
         task("javadoc${variant.name}", type: Javadoc) {
-            source = android.sourceSets.main.java.srcDirs
-            ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
-            classpath = files(android.sourceSets.main.java.srcDirs) + files(ext.androidJar)
+            source android.sourceSets.main.java.srcDirs
+            classpath = variant.javaCompileProvider.get().classpath + files(project.android.getBootClasspath()) + files("$buildDir/intermediates/classes/${variant.name}")
             options.links("http://docs.oracle.com/javase/7/docs/api/")
-            options.linksOffline("http://developer.android.com/reference/", "${android.sdkDirectory}/docs/reference/")
-            options.links("http://facebook.github.io/rebound/javadocs/")
             exclude '**/BuildConfig.java'
             exclude '**/R.java'
         }

--- a/backboard/build.gradle
+++ b/backboard/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'checkstyle'
+plugins {
+    id "com.android.library"
+    id "checkstyle"
+}
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion

--- a/backboard/build.gradle
+++ b/backboard/build.gradle
@@ -21,7 +21,7 @@ android {
 
     libraryVariants.all { variant ->
         task("javadoc${variant.name}", type: Javadoc) {
-            source = variant.javaCompile.source
+            source = android.sourceSets.main.java.srcDirs
             ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
             classpath = files(android.sourceSets.main.java.srcDirs) + files(ext.androidJar)
             options.links("http://docs.oracle.com/javase/7/docs/api/")

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ allprojects {
 }
 
 ext {
-	compileSdkVersion = 28
-	minSdkVersion = 14
-	targetSdkVersion = 28
-	supportAnnotation = 'androidx.annotation:annotation:1.0.0'
-	facebookRebound = "com.facebook.rebound:rebound:0.3.8"
+    compileSdkVersion = 31
+    minSdkVersion = 14
+    targetSdkVersion = 31
+    supportAnnotation = 'androidx.annotation:annotation:1.0.0'
+    facebookRebound = "com.facebook.rebound:rebound:0.3.8"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,29 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    repositories {
-		google()
-		jcenter()
-    }
-	dependencies {
-		// NOTE - this is referencing a local variable that you must set in your gradle.properties
-		// in the top level folder.
-		//
-		// Example:
-		//
-		// project.ext {
-		//    localBuildTools = com.android.tools.build:gradle:0.14.1
-		// }
-		//
-		if (project.hasProperty('localBuildTools')) {
-			classpath project.ext.localBuildTools
-		} else {
-			// Fallback to newest build tools if property not set
-			classpath 'com.android.tools.build:gradle:7.1.1'
-		}
-	}
-}
-
 allprojects {
     repositories {
 		google()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 allprojects {
     repositories {
-		google()
-		jcenter()
+	google()
+	mavenCentral()
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,14 @@
+pluginManagement {
+    gradle.ext.agpVersion = '7.1.1'
+
+    plugins {
+        id "com.android.application" version gradle.ext.agpVersion
+        id "com.android.library" version gradle.ext.agpVersion
+    }
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include ':backboard-example', ':backboard'


### PR DESCRIPTION
This PR builds on #24 and adds support for plugin DSL, updates compile/target sdk to `31` and fixes/improves the `javadoc` task.

* 1f7e7f92ad143ca6c1efbf1a76bd386fa9df10d8 adds support for plugin DSL. This change will mean that the Gradle property logic around `localBuildTools` is removed, however I don't think that's necessary for a standalone library. Please let me know if you disagree and I can try and bring it back with the new setup.
* 17b04f80ffcd40d565bab5f4c9be182b9170283a replaces deprecated `jcenter` with `mavenCentral`.
* 20847c907b2ecc19e4dc6e6147c6a0f5432f3cef updates compile/target sdk to `31`.
* ce16218e3933dfbe2ebab5c114cfd545de8da4ce updates the `source` for the `javadoc` task. My understanding is that this is the correct path, but since there are no official docs/examples for the usecase, I can't be sure.
* 5aa76148aa0a00c5847b0cb6788d304d7a138083 was a bit tricky and that's why it's separated from the previous commit. It updates the `classpath` to include the compile dependencies. Without this change `./gradlew javadocRelease` would fail with several errors where compiler can't find classes such as `@NonNull`. It also replaces the custom `androidJar` setup with the `getBootClasspath`. I _think_ this is correct, but (frustratingly) I have failed to find enough information on this.
* 5aa76148aa0a00c5847b0cb6788d304d7a138083 also removes the offline links, which didn't work for me as I don't have the `docs` folder and couldn't find how to download them. I don't think not having the offline links is a big loss, but if there is any disagreement, we can try to get it to work in the Docker image which is where it'll be used. It also removes the link to http://facebook.github.io/rebound/javadocs/ which is no longer available and forwards to https://opensource.fb.com/. I couldn't find the updated url as the project seems to have been deprecated.

Since there is some hesitation about the `javadoc` changes, one idea might be to compare the newly generated docs with the old ones if it's possible. I unfortunately don't have any prior knowledge on how to do that. It looks like the `javadoc` task was introduced in https://github.com/tumblr/Backboard/pull/10, so there might be some clues there.