### PR TITLE
Publish to s3

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,17 +20,9 @@ steps:
       - "**/build/reports/lint-results**.*"
       - "**/build/reports/checkstyle/checkstyle.*"
 
-  - label: "Test"
-    key: "test"
-    plugins:
-      - *docker-container
-    command: |
-      ./gradlew test
-
   - label: "Publish to S3 Maven"
     depends_on:
       - "lint_and_checkstyle"
-      - "test"
     plugins:
       - *docker-container
     command: |

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,5 +35,5 @@ steps:
       - *docker-container
     command: |
       ./gradlew \
-          prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
-          publish
+          :backboard:prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
+          :backboard:publish

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,39 @@
+common-params:
+  &docker-container
+  docker#v3.8.0:
+    image: "public.ecr.aws/automattic/android-build-image:v1.1.0"
+    propagate-environment: true
+    environment:
+      # DO NOT MANUALLY SET THESE VALUES!
+      # They are passed from the Buildkite agent to the Docker container
+      - "AWS_ACCESS_KEY"
+      - "AWS_SECRET_KEY"
+
+steps:
+  - label: "Lint & Checkstyle"
+    key: "lint_and_checkstyle"
+    plugins:
+      - *docker-container
+    command: |
+      ./gradlew lintRelease checkstyle
+    artifact_paths:
+      - "**/build/reports/lint-results**.*"
+      - "**/build/reports/checkstyle/checkstyle.*"
+
+  - label: "Test"
+    key: "test"
+    plugins:
+      - *docker-container
+    command: |
+      ./gradlew test
+
+  - label: "Publish to S3 Maven"
+    depends_on:
+      - "lint_and_checkstyle"
+      - "test"
+    plugins:
+      - *docker-container
+    command: |
+      ./gradlew \
+          prepareToPublishToS3 $(prepare_to_publish_to_s3_params) \
+          publish

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 # Backboard
 
-[![CircleCI](https://circleci.com/gh/tumblr/Backboard/tree/master.svg?style=svg)](https://circleci.com/gh/tumblr/Backboard/tree/master)
-
 A motion-driven animation framework for Android.
 
 `backboard` is a framework on top of [rebound](http://facebook.github.io/rebound/) that makes it easier to use by coupling it to views and motions.
@@ -19,6 +17,7 @@ A motion-driven animation framework for Android.
 ## Table of Contents
 
 * [Usage](#usage)
+* [Publishing a new version](#publishing-a-new-version)
 * [Getting Started](#getting-started)
     * [Performers](#performers)
     * [Imitators](#imitators)
@@ -32,11 +31,32 @@ A motion-driven animation framework for Android.
 Update your `build.gradle` with
 
 ```groovy
+repositories {
+    exclusiveContent {
+        forRepository {
+            maven {
+                url "https://a8c-libs.s3.amazonaws.com/android"
+            }
+        }
+        filter {
+            includeModule "com.tumblr", "backboard"
+        }
+    }
+}
+
 dependencies {
-   compile 'com.facebook.rebound:rebound:0.3.8'
-   compile 'com.tumblr:backboard:0.1.0'
+   implementation 'com.facebook.rebound:rebound:0.3.8'
+   implementation 'com.tumblr:backboard:0.2.0'
 }
 ```
+
+## Publishing a new version
+
+In the following cases, the CI will publish a new version with the following format to our S3 Maven repo:
+
+* For each commit in an open PR: `<PR-number>-<commit full SHA1>`
+* Each time a PR is merged to `master`: `master-<commit full SHA1>`
+* Each time a new tag is created: `{tag-name}`
 
 ## Getting Started
 

--- a/backboard/build.gradle
+++ b/backboard/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.android.library"
     id "checkstyle"
+    id "com.automattic.android.publish-to-s3"
 }
 
 android {
@@ -9,8 +10,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 102
-        versionName "0.1.2"
     }
     buildTypes {
         release {
@@ -65,4 +64,20 @@ dependencies {
     implementation rootProject.ext.supportAnnotation
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+}
+
+project.afterEvaluate {
+    publishing {
+        publications {
+            BackboardPublication(MavenPublication) {
+                from components.release
+
+                groupId "com.tumblr"
+                artifactId "backboard"
+                artifact tasks.named("androidSourcesJar") // This task is added by 'publish-to-s3' plugin
+                artifact tasks.named("javadocrelease")
+                // version is set by 'publish-to-s3' plugin
+            }
+        }
+   }
 }

--- a/backboard/build.gradle
+++ b/backboard/build.gradle
@@ -27,6 +27,12 @@ android {
             exclude '**/R.java'
         }
     }
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 checkstyle {
@@ -74,8 +80,6 @@ project.afterEvaluate {
 
                 groupId "com.tumblr"
                 artifactId "backboard"
-                artifact tasks.named("androidSourcesJar") // This task is added by 'publish-to-s3' plugin
-                artifact tasks.named("javadocrelease")
                 // version is set by 'publish-to-s3' plugin
             }
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,8 +4,16 @@ pluginManagement {
     plugins {
         id "com.android.application" version gradle.ext.agpVersion
         id "com.android.library" version gradle.ext.agpVersion
+        id "com.automattic.android.publish-to-s3" version "0.7.0"
     }
     repositories {
+        maven {
+            url 'https://a8c-libs.s3.amazonaws.com/android'
+            content {
+                includeGroup "com.automattic.android"
+                includeGroup "com.automattic.android.publish-to-s3"
+            }
+        }
         google()
         mavenCentral()
     }


### PR DESCRIPTION
This PR integrates Buildkite and adds support for publishing the library artifacts to S3 Maven. It follows our standard Buildkite configuration file and publish-to-s3 Gradle plugin setup.

* There are 2 CI steps, one to verify checkstyle & lint and one to publish to s3. The publishing job depends on the lint & checkstyle job. The publishing step uses a script we have in the Docker image to pass Buildkite environment information to the `prepareToPublishToS3` task.
* The publishing is done by [Maven Publish Plugin](https://docs.gradle.org/current/userguide/publishing_maven.html). We use [our own Gradle plugin](https://github.com/Automattic/publish-to-s3-gradle-plugin) to simplify its setup and have consistency across libraries. This plugin is the one that adds the [prepareToPublishToS3](https://github.com/Automattic/publish-to-s3-gradle-plugin/blob/trunk/plugin/src/main/kotlin/com/automattic/android/PrepareToPublishToS3Task.kt) task which calculates the version, updates the information for maven-publish plugin and verifies that the version is not already published.
* The specified version information is removed from `build.gradle` as this is now dynamically calculated at the time of publishing.
* For the first time, I've used the newly introduced `publishing` block from AGP `7.1.0` to publish the `-javadoc.jar` & `-sources.jar` files. I've verified that the files are in our S3 and tested the Tumblr client, but I'd appreciate if it can also be verified by the reviewer. I added instructions on how to do that in the client PR as it wouldn't be possible to easily test it in this PR.

**README Updates**
* For the `repositories` section, it recommends using [exclusiveContent](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/repositories/ExclusiveContentRepository.html) syntax which makes the S3 Maven the only possible repository to fetch the `Backboard` library artifacts. This is an extra security measure to guard against dependency hijacking attacks.
* Information about how to publish a new version and how that version will be formatted has been added. Note that Buildkite logs also contain information about the published version.
* After this PR is merged, I think we should create a new `0.2.0` tag. This is why I opted to use this version in the `README`.

**To Test**

There are no testing instructions specific to this PR. However, since this PR builds on #24 & #25, there is a Tumblr client PR that can be used to test the changes made in these PRs and verify that it's correctly published to S3.