### PR TITLE
Update publish-to-s3 Gradle plugin to 0.9.0

### DIFF
--- a/backboard/build.gradle
+++ b/backboard/build.gradle
@@ -27,12 +27,6 @@ android {
             exclude '**/R.java'
         }
     }
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
 }
 
 checkstyle {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,11 @@
 pluginManagement {
     gradle.ext.agpVersion = '7.1.1'
+    gradle.ext.automatticPublishToS3Version = '0.9.0'
 
     plugins {
         id "com.android.application" version gradle.ext.agpVersion
         id "com.android.library" version gradle.ext.agpVersion
-        id "com.automattic.android.publish-to-s3" version "0.9.0"
+        id "com.automattic.android.publish-to-s3" version gradle.ext.automatticPublishToS3Version
     }
     repositories {
         maven {

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     plugins {
         id "com.android.application" version gradle.ext.agpVersion
         id "com.android.library" version gradle.ext.agpVersion
-        id "com.automattic.android.publish-to-s3" version "0.7.0"
+        id "com.automattic.android.publish-to-s3" version "0.9.0"
     }
     repositories {
         maven {


### PR DESCRIPTION
We added Android publishing block support to publish-to-s3 Gradle plugin in https://github.com/Automattic/publish-to-s3-gradle-plugin/pull/31. With this change, we don't need to add the `publishing` block to `android` extension from individual modules anymore.

I am making this change to prepare the library for a future AGP 8.0 update, so releasing a new version is not necessary at the moment.

**To Test**

Verify that `buildkite/backboard/publish-to-s3-maven` CI job is successful